### PR TITLE
Add implicit createdBy to programme creation view

### DIFF
--- a/match/tests/test_api_programme.py
+++ b/match/tests/test_api_programme.py
@@ -38,6 +38,21 @@ class ProgrammeAPITests(TestCaseUtils, APITestCase):
         response = self.client.post(url, data, format='json', HTTP_AUTHORIZATION=self._get_auth_header(token=token.token))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_can_create_programme_with_implicit_author(self):
+        url = reverse('programme-list')
+        data = {
+            'name': 'Test Programme',
+            'description': 'This is a test programme',
+            'defaultCohortSize': 100
+        }
+        token = self._create_token(self.staff_user, 'write staff')
+        response = self.client.post(url, data, format='json', HTTP_AUTHORIZATION=self._get_auth_header(token=token.token))
+        print(response.content)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response_data = ProgrammeSerializer(data=json.loads(response.content.decode('utf-8')))
+        self.assertTrue(response_data.is_valid())
+        self.assertEqual(response_data.data['createdBy'], self.staff_user.pk)
+
     def test_cant_create_programme_if_not_staff(self):
         url = reverse('programme-list')
         data = {

--- a/match/tests/test_api_programme.py
+++ b/match/tests/test_api_programme.py
@@ -47,7 +47,6 @@ class ProgrammeAPITests(TestCaseUtils, APITestCase):
         }
         token = self._create_token(self.staff_user, 'write staff')
         response = self.client.post(url, data, format='json', HTTP_AUTHORIZATION=self._get_auth_header(token=token.token))
-        print(response.content)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_data = ProgrammeSerializer(data=json.loads(response.content.decode('utf-8')))
         self.assertTrue(response_data.is_valid())
@@ -60,6 +59,17 @@ class ProgrammeAPITests(TestCaseUtils, APITestCase):
             'description': 'This is a test programme.',
             'defaultCohortSize': 100,
             'createdBy': self.test_user.pk
+        }
+        token = self._create_token(self.test_user, 'write staff')
+        response = self.client.post(url, data, format='json', HTTP_AUTHORIZATION=self._get_auth_header(token=token.token))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cant_create_programme_if_not_staff_with_implicit_author(self):
+        url = reverse('programme-list')
+        data = {
+            'name': 'Test Programme',
+            'description': 'This is a test programme.',
+            'defaultCohortSize': 100
         }
         token = self._create_token(self.test_user, 'write staff')
         response = self.client.post(url, data, format='json', HTTP_AUTHORIZATION=self._get_auth_header(token=token.token))

--- a/match/views/programme.py
+++ b/match/views/programme.py
@@ -23,6 +23,12 @@ class ProgrammeViewSet(viewsets.ModelViewSet):
             self.required_scopes = ['write', 'staff']
         return super(self.__class__, self).get_permissions()
 
+    def create(self, request, **kwargs):
+        # implicitly add createdBy attribute
+        if not 'createdBy' in request.data:
+            request.data['createdBy'] = request.user.pk
+        return super(self.__class__, self).create(request, **kwargs)
+
     def partial_update(self, request, **kwargs):
         # Prevent non-owner from patching this object.
         p = Programme.objects.get(programmeId=self.kwargs['programmeId'])


### PR DESCRIPTION
Fixes issue #6.

Allows API users to create programmes without having to explicitly
include the `createdBy` attrbute. Instead it's obtained from the
session token.