### PR TITLE
Add methods to find "active" cohort of a programme

### DIFF
--- a/match/serializers.py
+++ b/match/serializers.py
@@ -118,7 +118,6 @@ class ProgrammeSerializer(serializers.ModelSerializer):
 class CohortSerializer(serializers.ModelSerializer):
     createdBy = UserSerializer(required=False, read_only=True)
     programme = ProgrammeSerializer(required=False, read_only=True)
-    participantCount = serializers.IntegerField(source='participants.count', read_only=True)
 
     class Meta:
         model = models.Cohort
@@ -134,7 +133,6 @@ class CohortSerializer(serializers.ModelSerializer):
         )
 
 class ParticipantSerializer(serializers.ModelSerializer):
-    # tags = TagSerializer(many=True, required=False)
     tags = CreatableSlugRelatedField(many=True,
             slug_field="name", 
             filter_field="slug",

--- a/match/tests/test_model_programme.py
+++ b/match/tests/test_model_programme.py
@@ -1,7 +1,9 @@
 from django.contrib.auth.models import User
 from django.db.utils import IntegrityError
 from django.test import TestCase
+from django.utils import timezone
 from match.models import Programme
+from datetime import timedelta
 
 class ProgrammeModelTests(TestCase):
     def setUp(self):
@@ -26,6 +28,215 @@ class ProgrammeModelTests(TestCase):
 
     def test_default_cohort_size_implicitly_set(self):
         self.assertEqual(self._create_test_programme().defaultCohortSize, 100)
+
+    # activeCohort tests
+    def test_active_cohort_is_none_when_no_cohorts(self):
+        p = self._create_test_programme()
+        self.assertIsNone(p.activeCohort)
+
+    def test_active_cohort_is_set_when_open_cohort_with_spaces(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=7),
+            createdBy=self._user
+        )
+        self.assertEqual(p.activeCohort, c1)
+    
+    def test_active_cohort_is_set_when_open_cohort_with_no_spaces(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c1.participants.create(
+            user=self._user,
+            isMentor=True
+        )
+        self.assertEqual(p.activeCohort, c1)
+
+    def test_active_cohort_is_none_when_cohort_not_yet_open(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() + timedelta(days=2),
+            createdBy=self._user
+        )
+        self.assertIsNone(p.activeCohort)   
+
+    def test_active_cohort_is_none_when_cohort_closed(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() - timedelta(days=1),
+            createdBy=self._user
+        )
+        self.assertIsNone(p.activeCohort)
+    
+    def test_active_cohort_is_second_when_first_cohort_full(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c1.participants.create(
+            user=self._user,
+            isMentor=True,
+        )
+        self.assertEqual(p.activeCohort, c2)
+
+    def test_active_cohort_is_earliest_when_more_than_one(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=7),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        self.assertEqual(p.activeCohort, c1)
+    
+    def test_active_cohort_is_earliest_when_more_than_one_and_earliest_not_full(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=7),
+            cohortSize=2,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c1.participants.create(
+            user=self._user,
+            isMentor=True
+        )
+        self.assertEqual(p.activeCohort, c1)
+
+    def test_active_cohort_is_second_when_first_is_closed(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=7),
+            closeDate=timezone.now() - timedelta(days=2),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        self.assertEqual(p.activeCohort, c2)
+
+    def test_active_cohort_is_second_when_first_is_closed_and_second_is_full(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=7),
+            closeDate=timezone.now() - timedelta(days=2),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2.participants.create(
+            user=self._user,
+            isMentor=True
+        )
+        self.assertEqual(p.activeCohort, c2)
+
+    def test_active_cohort_is_second_when_both_active_and_second_opens_earlier(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() + timedelta(days=7),
+            closeDate=timezone.now() + timedelta(days=2),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=9),
+            closeDate=timezone.now() + timedelta(days=2),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        self.assertEqual(p.activeCohort, c2)
+
+    def test_active_cohort_is_second_when_first_is_not_open_and_second_is_full(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() + timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2.participants.create(
+            user=self._user,
+            isMentor=True
+        )
+        self.assertEqual(p.activeCohort, c2)
+
+    def test_active_cohort_is_none_when_no_cohorts_are_open(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() + timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() + timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=5),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        self.assertIsNone(p.activeCohort)
+
+    def test_active_cohort_is_earliest_when_both_are_full(self):
+        p = self._create_test_programme()
+        c1 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=2),
+            closeDate=timezone.now() + timedelta(days=7),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c2 = p.cohorts.create(
+            openDate=timezone.now() - timedelta(days=3),
+            closeDate=timezone.now() + timedelta(days=5),
+            cohortSize=1,
+            createdBy=self._user
+        )
+        c1.participants.create(
+            user=self._user,
+            isMentor=True
+        )
+        c2.participants.create(
+            user=self._user,
+            isMentor=True
+        )
+        self.assertEqual(p.activeCohort, c2)
 
     # Creates a generic programme
     def _create_test_programme(self):

--- a/match/views/programme.py
+++ b/match/views/programme.py
@@ -61,6 +61,19 @@ class ProgrammeViewSet(viewsets.ModelViewSet):
         except Cohort.DoesNotExist:
             return JSONResponse(None, status=status.HTTP_204_NO_CONTENT)
 
+    @decorators.detail_route(methods=['get'], required_scopes=['read'])
+    def cohort_active(self, request, **kwargs):
+        programme = Programme.objects.get(programmeId=kwargs['programmeId'])
+        if not programme:
+            return JSONResponse({'detail': 'Programme not found'}, status=status.HTTP_404_NOT_FOUND)
+        cohort = programme.activeCohort
+        if cohort:
+            serializer = CohortSerializer(cohort)
+            return JSONResponse(serializer.data, status=status.HTTP_200_OK)
+        else:
+            return JSONResponse({}, status=status.HTTP_404_NOT_FOUND)
+
+
     @decorators.detail_route(methods=['post'], required_scopes=['write staff'])
     def cohort_create(self, request, **kwargs):
         programme = Programme.objects.get(programmeId=kwargs['programmeId'])
@@ -90,6 +103,10 @@ programme_detail = ProgrammeViewSet.as_view({
     'delete': 'destroy'
 })
 
+programme_active_cohort = ProgrammeViewSet.as_view({
+    'get': 'cohort_active',
+})
+
 programme_cohort = ProgrammeViewSet.as_view({
     'post': 'cohort_create',
     'get': 'cohort_list',
@@ -97,6 +114,7 @@ programme_cohort = ProgrammeViewSet.as_view({
 
 urlpatterns = [
     url(r'^$', programme_list, name='programme-list'),
-    url(r'^(?P<programmeId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/cohorts', programme_cohort, name='programme-cohort-list'),
-    url(r'^(?P<programmeId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', programme_detail, name='programme-detail'),
+    url(r'^(?P<programmeId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', programme_detail, name='programme-detail'),
+    url(r'^(?P<programmeId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/cohorts/$', programme_cohort, name='programme-cohort-list'),
+    url(r'^(?P<programmeId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/cohorts/active$', programme_active_cohort, name='programme-active-cohort'),
 ]


### PR DESCRIPTION
Fixes #18.

Adds an `activeCohort` attribute to the `Programme` model, which
finds the current in-use cohort of a programme. This acts as a
shortcut for API clients, so that they don't need to waste time
searching around for the recommended cohort, if there is one.

This initial commit adds the model attribute, but this pull request
will also contain a `/programme/<id>/cohorts/active` endpoint that returns
this active cohort.